### PR TITLE
dropping loanwords

### DIFF
--- a/loanwords.json
+++ b/loanwords.json
@@ -343,17 +343,6 @@
     ]
   },
   {
-    "word": "avlli",
-    "origin": "ottoman",
-    "adaptations": [
-      "avlli"
-    ],
-    "alternatives": [
-      "mur rrethues i oborrit",
-      "gardh"
-    ]
-  },
-  {
     "word": "sehir",
     "origin": "ottoman",
     "adaptations": [


### PR DESCRIPTION
In PR #3, a loanword was brought up with a suggestion of removing it or adding another word to its alternatives. This PR contains the change for dropping it.